### PR TITLE
ci: update actions ci and fix browserslist warning

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,13 +1,9 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Node.js CI
 
 on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
 
 jobs:
   build:
@@ -15,14 +11,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node: [14.x]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.node }}
       - run: npm ci
       - run: npm test
       - name: Upload coverage to Codecov

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ express-pug-static
 =============================================================================================================================================
 
 [![npm version](https://badge.fury.io/js/express-pug-static.svg)](https://badge.fury.io/js/express-pug-static)
-![Build Status](https://github.com/Adslot/express-pug-static/workflows/Node.js%20CI/badge.svg)
+![Build Status](https://github.com/Adslot/express-pug-static/actions/workflows/node.js.yml/badge.svg)
 [![codecov](https://codecov.io/gh/Adslot/express-pug-static/branch/master/graph/badge.svg)](https://codecov.io/gh/Adslot/express-pug-static)
 
 Connect (ExpressJS) middleware for serving pug files as static html

--- a/package-lock.json
+++ b/package-lock.json
@@ -710,9 +710,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001194",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001194.tgz",
-      "integrity": "sha512-iDUOH+oFeBYk5XawYsPtsx/8fFpndAPUQJC7gBTfxHM8xw5nOZv7ceAD4frS1MKCLUac7QL5wdAJiFQlDRjXlA==",
+      "version": "1.0.30001261",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001261.tgz",
+      "integrity": "sha512-vM8D9Uvp7bHIN0fZ2KQ4wnmYFpJo/Etb4Vwsuc+ka0tfGDHvOPrFm6S/7CCNLSOkAUjenT2HnUPESdOIL91FaA==",
       "dev": true
     },
     "chalk": {


### PR DESCRIPTION
- Update actions workflows to use `setup-node@v2`
- Update `caniuse-lite` to fix browserslist warning