### PR TITLE
v1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "express-pug-static",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "express-pug-static",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "pug": "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-pug-static",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Connect (expressjs) middleware for serving html files from pug template",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Changes

- [d440ca07405e9600d43d56b6cf948556866e4819] chore(deps): update dependency mocha to ^10.1.0
 
- [7e122f90bf73320df6ab23bcb8e9dd855be518d4] chore(deps): update actions/dependency-review-action action to v3
 
- [49d49a89a53f8df854f7039242fcf2f50e69cc9e] build(deps): bump json5 from 2.2.0 to 2.2.3
 
	


	Bumps [json5](https://github.com/json5/json5) from 2.2.0 to 2.2.3.


	- [Release notes](https://github.com/json5/json5/releases)


	- [Changelog](https://github.com/json5/json5/blob/main/CHANGELOG.md)


	- [Commits](https://github.com/json5/json5/compare/v2.2.0...v2.2.3)


	


	---


	updated-dependencies:


	- dependency-name: json5


	  dependency-type: indirect


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [ce84494712b9cf9739457a124628dcd8c08b336b] chore(deps): update dependency mocha to ^10.2.0
 
- [50c0e222e3d53c7092622e56116576fcfdf486d3] ci: add  --update-notifier=false for npm ci
 
- [fa3175a4b1332988a2b9b9a830345c75968c9902] chore(deps): update actions/checkout action to v4
 
- [76a866f0e7359385972ad3f0822924aadc172c9f] build(deps-dev): bump @babel/traverse from 7.13.0 to 7.23.2
 
	


	Bumps [@babel/traverse](https://github.com/babel/babel/tree/HEAD/packages/babel-traverse) from 7.13.0 to 7.23.2.


	- [Release notes](https://github.com/babel/babel/releases)


	- [Changelog](https://github.com/babel/babel/blob/main/CHANGELOG.md)


	- [Commits](https://github.com/babel/babel/commits/v7.23.2/packages/babel-traverse)


	


	---


	updated-dependencies:


	- dependency-name: "@babel/traverse"


	  dependency-type: indirect


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [816fef2662d5035814a37a277a26a0a506a7d861] chore: upgrade to node 20
 
- [7e7b574e3dcfa8449f8d634187bf9faa8a91b136] build: release minor version 1.4.0
 

### Comparison
https://github.com/Adslot/express-pug-static/compare/v1.3.0...v1.4.0