### PR TITLE
v1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "express-pug-static",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "express-pug-static",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "pug": "^3.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-pug-static",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Connect (expressjs) middleware for serving html files from pug template",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Changes

- [11df8332316c28ab474a5e44d2baa9604de4e7b6] build(deps-dev): bump braces from 3.0.2 to 3.0.3
 
	


	Bumps [braces](https://github.com/micromatch/braces) from 3.0.2 to 3.0.3.


	- [Changelog](https://github.com/micromatch/braces/blob/master/CHANGELOG.md)


	- [Commits](https://github.com/micromatch/braces/compare/3.0.2...3.0.3)


	


	---


	updated-dependencies:


	- dependency-name: braces


	  dependency-type: indirect


	...


	


	Signed-off-by: dependabot[bot] <support@github.com>

- [7c70e36faa6a0095f0c7c643908d75967cd4fc59] chore(deps): update dependency mocha to ^10.5.2
 
- [70891bb15bd8020e953168fa7570c55edea40e28] chore(deps): update dependency nyc to v17
 
- [2a1206a30c8c3a0c55ff9b4a2202b21c3764324e] chore(deps): update devdeps
 
- [04442c0d3297f6061afb575951f2b90adcd33e37] chore: upgrade to node 22
 
- [581e24780368005536937bbc8a2cd5a553735fe8] chore: run npm audit fix
 
- [0f2107d7b245ecd56716df9955a592e4597e8631] build: release minor version 1.5.0
 

### Comparison
https://github.com/Adslot/express-pug-static/compare/v1.4.2...v1.5.0